### PR TITLE
BLTouch Speed up

### DIFF
--- a/TH3DUF_R2/Conditionals_LCD.h
+++ b/TH3DUF_R2/Conditionals_LCD.h
@@ -490,7 +490,7 @@
     #define SERVO_DELAY { 50 }
   #endif
   #ifndef BLTOUCH_DELAY
-    #define BLTOUCH_DELAY 375
+    #define BLTOUCH_DELAY 100
   #endif
   #undef Z_SERVO_ANGLES
   #define Z_SERVO_ANGLES { BLTOUCH_DEPLOY, BLTOUCH_STOW }

--- a/TH3DUF_R2/Configuration_backend.h
+++ b/TH3DUF_R2/Configuration_backend.h
@@ -2256,9 +2256,9 @@
 #endif
 
 #if DISABLED(EZABL_FASTPROBE)
-  #define HOMING_FEEDRATE_Z  (4*60)
+  #define HOMING_FEEDRATE_Z  (20*60)
 #else
-  #define HOMING_FEEDRATE_Z  (8*60)
+  #define HOMING_FEEDRATE_Z  (20*60)
 #endif
   
 #if ENABLED(EZABL_ENABLE)
@@ -2268,10 +2268,10 @@
   #endif
   #define Z_PROBE_OFFSET_FROM_EXTRUDER 0
   #if ENABLED(PROBING_MOTORS_OFF)
-    #define XY_PROBE_SPEED 8000
+    #define XY_PROBE_SPEED 12000
   #else
     #if ENABLED(SLOWER_PROBE_MOVES) || ENABLED(TH3D_EZ300)
-      #define XY_PROBE_SPEED 8000
+      #define XY_PROBE_SPEED 12000
     #else
       #define XY_PROBE_SPEED 12000
     #endif
@@ -2283,8 +2283,8 @@
   #endif  
   #define MULTIPLE_PROBING 2
   #if ENABLED(BLTOUCH)
-    #define Z_CLEARANCE_DEPLOY_PROBE   15
-    #define Z_CLEARANCE_BETWEEN_PROBES 10
+    #define Z_CLEARANCE_DEPLOY_PROBE   5
+    #define Z_CLEARANCE_BETWEEN_PROBES 4
   #else
     #define Z_CLEARANCE_DEPLOY_PROBE   5
     #define Z_CLEARANCE_BETWEEN_PROBES 3


### PR DESCRIPTION
Hi Tim, 

You asked on a you tube comment a few weeks ago for my speed up BLT changes.
Most of which are pretty straight forward, there are a couple that might not be for BLT but just for the EZABL.   I'm sure you can confirm when you review.

I have tested these on my ender3 and bed levelling is down to ~40sec.

Also this is the first time I have used GIT, so open constructive criticisms... 

Cheers. 

p.s. I'm running the BLT with the EZout via pin 29, but have to drop SDsuport for space, if you could point me in the right direction to shave off 400bytes. maybe drop some more menu items, i never use the move options, I do almost everything by octopi. I'm not sure where to poke around for that...     