### PR TITLE
Don't use a specific version for Creality TMC boards

### DIFF
--- a/TH3DUF_R2/Configuration.h
+++ b/TH3DUF_R2/Configuration.h
@@ -176,7 +176,7 @@
 //#define PETSFANG //This is the RIGHT mounted version - if using the left mount please use the CUSTOM_PROBE option.
 //#define CUSTOM_PROBE
 
-// TMC2208 V1.1.4 Board Setting - uncomment this to set the driver type if you are using the TMC V1.1.4 board
+// TMC2208 Creality Board Setting - uncomment this to set the driver type if you are using the TMC Creality board
 //#define TMC_CREALITY_BOARD
 
 //===========================================================================
@@ -298,7 +298,7 @@
 //#define PETSFANG  //This is the RIGHT mounted version - if using the left mount please use the CUSTOM_PROBE option.
 //#define CUSTOM_PROBE
 
-// TMC2208 V1.1.4 Board Setting - uncomment this to set the driver type if you are using the TMC V1.1.4 board
+// TMC2208 Creality Board Setting - uncomment this to set the driver type if you are using the TMC Creality board
 //#define TMC_CREALITY_BOARD
 
 //=================================================================================================
@@ -363,7 +363,7 @@
 //#define PETSFANG  //This is the RIGHT mounted version - if using the left mount please use the CUSTOM_PROBE option.
 //#define CUSTOM_PROBE
 
-// TMC2208 V1.1.4 Board Setting - uncomment this to set the driver type if you are using the TMC V1.1.4 board
+// TMC2208 Creality Board Setting - uncomment this to set the driver type if you are using the TMC Creality board
 //#define TMC_CREALITY_BOARD
 
 //=================================================================================================


### PR DESCRIPTION
Because there is also a new version of the Creality TMC (silent) board - v1.1.5 (https://www.creality3donline.com/silentmainboard_p0165.html), which is 100% compatible with the older v1.14 version, it is much better referring these boards in comments as "Creality TMC boards".