### PR TITLE
Setting to enable ACTION_ON_PAUSE/ACTION_ON_RESUME

### DIFF
--- a/TH3DUF_R2/Configuration.h
+++ b/TH3DUF_R2/Configuration.h
@@ -1079,6 +1079,14 @@
 //#define JUNCTION_DEVIATION_ON
 //#define S_CURVE_ACCELERATION_ON
 
+// HOST ACTION TRIGGER
+// Enabling this turns on 2 new trigger on a filament change (M600) to let OctoPi and other compatible software know
+// that we are pausing for a filament change. This way the host can wait before sending new commands/react to it with
+// a custom action. Once the filament change is done, another action is send to the host and letting it know things go
+// on.
+
+//#define PAUSE_ACTION_OCTOPI
+
 //================================================================================================
 // Language - This is provided for convenience and is unsupported with included product support.
 // We only test compile with English language. If you run into space issues disable some features.

--- a/TH3DUF_R2/Configuration.h
+++ b/TH3DUF_R2/Configuration.h
@@ -1084,8 +1084,13 @@
 // that we are pausing for a filament change. This way the host can wait before sending new commands/react to it with
 // a custom action. Once the filament change is done, another action is send to the host and letting it know things go
 // on.
+// Enable PAUSE_ACTION_OCTOPI when you want the M600 handled by Marlin completely. OctoPi switches to pause/resume, but
+// doesn't trigger any GCODE/SD commands
+// Enable PAUSE_ACTION_DEFAULT when you want the M600 triggering GCODE scripts/SD commands when OctoPi pause/resumes. Also
+// use this when you use a different host then OctoPi as it's the default event and should be supported by other hosts.
 
 //#define PAUSE_ACTION_OCTOPI
+//#define PAUSE_ACTION_DEFAULT
 
 //================================================================================================
 // Language - This is provided for convenience and is unsupported with included product support.

--- a/TH3DUF_R2/Configuration_adv.h
+++ b/TH3DUF_R2/Configuration_adv.h
@@ -354,6 +354,9 @@
   #if ENABLED(PAUSE_ACTION_OCTOPI)
     #define ACTION_ON_PAUSE "paused"
     #define ACTION_ON_RESUME "resumed"
+  #elif ENABLED(PAUSE_ACTION_DEFAULT)
+    #define ACTION_ON_PAUSE "pause"
+    #define ACTION_ON_RESUME "resume"
   #endif  
 #endif
 

--- a/TH3DUF_R2/Configuration_adv.h
+++ b/TH3DUF_R2/Configuration_adv.h
@@ -351,6 +351,10 @@
   #define FILAMENT_CHANGE_ALERT_BEEPS         10 
   #define PAUSE_PARK_NO_STEPPER_TIMEOUT          
   #define PARK_HEAD_ON_PAUSE
+  #if ENABLED(PAUSE_ACTION_OCTOPI)
+    #define ACTION_ON_PAUSE "paused"
+    #define ACTION_ON_RESUME "resumed"
+  #endif  
 #endif
 
 #define AUTO_REPORT_TEMPERATURES


### PR DESCRIPTION
It's just a little patch that enables users running the print with a host letting the host know that a pause (filament action) is happening and later a things can go on (resume). Before OctoPi in my case kept sending commands, not realising that something is happening. The print does resume alright but with delay as OctoPi kept sending lots of M117 messages which he did display before resuming. So with this, OctoPi switches during the M600 into pause mode, and after the M600 into resume. Depending on the setting choosen from the 2 new ones I added, this also can be used to trigger a action on the host (OctoPi or whatever the people use) in terms of setting off a script if supported by the host. I think its a small change with pretty much zero space (code is present in the FW anyway just don't trigger) use but quite a bit use for the user.