### PR TITLE
Update Version.h

### DIFF
--- a/TH3DUF_R2/Version.h
+++ b/TH3DUF_R2/Version.h
@@ -121,8 +121,8 @@
 
   /**
    * The SOURCE_CODE_URL is the location where users will find the Marlin Source
-   * Code which is installed on the device. In most cases —unless the manufacturer
-   * has a distinct Github fork— the Source Code URL should just be the main
+   * Code which is installed on the device. In most cases -unless the manufacturer
+   * has a distinct Github fork- the Source Code URL should just be the main
    * Marlin repository.
    */
   #if ENABLED(WANHAO_I3_PLUS)


### PR DESCRIPTION
Fix invalid characters for encoding. Resolves the following warning in Arduino IDE:
"Version.h" contains unrecognised characters. If this code was created with an older version of Arduino, you may need to use Tools -> Fix Encoding & Reload to update the sketch to use UTF-8 encoding. If not, you may need to delete the bad characters to get rid of this warning.